### PR TITLE
Add optional version_id param to S3 signer

### DIFF
--- a/lib/Signer/AWSv4/S3.pm
+++ b/lib/Signer/AWSv4/S3.pm
@@ -5,6 +5,7 @@ package Signer::AWSv4::S3;
 
   has bucket => (is => 'ro', isa => Str, required => 1);
   has key => (is => 'ro', isa => Str, required => 1);
+  has version_id => (is => 'ro', isa => Str);
 
   has '+service' => (default => 's3');
   has '+uri' => (init_arg => undef, lazy => 1, default => sub {
@@ -31,6 +32,7 @@ package Signer::AWSv4::S3;
       'X-Amz-Date' => $self->date_timestamp,
       'X-Amz-Expires' => $self->expires,
       'X-Amz-SignedHeaders' => $self->signed_header_list,
+      (versionId => $self->version_id) x!! $self->version_id,
     }
   }
 

--- a/t/02_s3.t
+++ b/t/02_s3.t
@@ -41,4 +41,19 @@ cmp_ok($signer->signature, 'eq', $signature);
 my $expected_signed_qstring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=733255ef022bec3f2a8701cd61d4b371f3f28c9f193a1f02279211d48d5193d7';
 cmp_ok($signer->signed_qstring, 'eq', $expected_signed_qstring);
 
+$signer = Signer::AWSv4::S3->new(
+  time => Time::Piece->strptime('20130524T000000Z', '%Y%m%dT%H%M%SZ'),
+  access_key => 'AKIAIOSFODNN7EXAMPLE',
+  secret_key => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  method => 'GET',
+  key => 'test.txt',
+  bucket => 'examplebucket',
+  region => 'us-east-1',
+  expires => 86400,
+  version_id => '1234561zOnAAAJKHxVKBxxEyuy_78901j',
+);
+
+$expected_signed_qstring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&versionId=1234561zOnAAAJKHxVKBxxEyuy_78901j&X-Amz-Signature=0b515992717e5e9c6813f66947ca059e80df2331fca5989554e8c8b51c729321';
+cmp_ok($signer->signed_qstring, 'eq', $expected_signed_qstring);
+
 done_testing;


### PR DESCRIPTION
This allows generating signed links for specific versions of objects in
a bucket with versioning enabled